### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ torch>1.10.0
 torchvision
 transformers>=4.27.1
 mdtex2html
-gradio
+gradio=3.28.0


### PR DESCRIPTION
更新 requirements.txt

本次提交更新了 requirements.txt 文件，解决了一个bug，原版本int4运行web_demo_hf.py，吐出的字带html符号 。这是因为默认下载的gradio版本过高所致，默认是3.32.0改成3.28.0之后，这个问题就解决了

请审查并合并此更新。

谢谢。